### PR TITLE
[Fix teamwarren/blacktechdaily#4] Dark mode glitch

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,11 @@ import './App.css';
 import ArticlesFeed from './components/articles-feed/articles-feed'
 
 const App = () => {
-  const [mode, setMode] = useState(localStorage.getItem('cachedMode') || '');
+  const [mode, setMode] = useState(localStorage.getItem('cachedMode') ?? 'light');
+  if (!(mode === 'light' || mode === 'dark')) {
+    setMode('light');
+  }
+
   const modeText = mode === 'light' ? 'dark' : 'light';
 
   useEffect(() => {


### PR DESCRIPTION
[Fix teamwarren/blacktechdaily#4] Dark mode glitch

Cause:
    localstorage.getItem() returned a null value if the item does not exist so the RHS was used resulting in mode === ''

Solution:
    Modify useState() to use the ?? operator to handle null values
    Modify the RHS of ?? so that useState() will default to 'light'
    Sanitize values of mode and default to 'light' if the current value is invalid

Branch:
    main